### PR TITLE
Improve checking if the zmqclient is used from multiple threads

### DIFF
--- a/python/mujinzmqclient/zmqclient.py
+++ b/python/mujinzmqclient/zmqclient.py
@@ -296,12 +296,11 @@ class ZmqClient(object):
         callerthread = threading.current_thread()
         if self._callerthreadref is not None:
             oldcallerthread = self._callerthreadref() # Get local ref for thread-safety.
-            oldcallercontext = self._callercontext
             # Do not bother checking further if the last thread that called the client has already been joined. No danger of race condition in that case
             if oldcallerthread is not None and oldcallerthread.is_alive():
                 # assert oldcallerthread == callerthread, 'zmqclient used from multiple threads: previously = %s, now = %s' % (oldcallerthread, callerthread)
                 if oldcallerthread.native_id != callerthread.native_id:
-                    log.error('zmqclient used from multiple threads, this is a bug in the caller: previously = %s, now = %s, previous context = %s, new context = %s', repr(oldcallerthread), repr(callerthread), repr(oldcallercontext)[:100], repr(context)[:100])
+                    log.error('zmqclient used from multiple threads, this is a bug in the caller: previously = %s, now = %s, previous context = %s, new context = %s', repr(oldcallerthread), repr(callerthread), repr(self._callercontext)[:100], repr(context)[:100])
 
         self._callerthreadref = weakref.ref(callerthread)
         self._callercontext = context

--- a/python/mujinzmqclient/zmqclient.py
+++ b/python/mujinzmqclient/zmqclient.py
@@ -227,7 +227,7 @@ class ZmqClient(object):
     _pool = None
     _socket = None
     _isok = False
-    _callerthread = None  # Last caller thread
+    _callerthreadref = None  # Weak reference to last caller thread
     _callercontext = None  # The context of the last caller
 
     def __init__(self, hostname='', port=0, ctx=None, limit=100, url=None, checkpreemptfn=None, reusetimeout=10.0):


### PR DESCRIPTION
## Summary  
The same zmqclient might be used from multiple threads safely if the previous thread to use the client has already been joined (is no longer alive). In that case, there is no danger of a race condition. 

Log an error about using the same client from multiple threads only if the previous thread to have used the client is still alive.  

## Working
Confirmed the working with the following snippet:
<details>
<summary>Click to expand</summary>

```python
import threading
import weakref
from time import sleep

class ThreadChecker():

    def __init__(self):
        self._callerthreadref = None
        self._callercontext = None

    def _CheckCallerThread(self, context=None):
        """Catch bad callers who use zmq client from multiple threads and cause random race conditions.
        """
        callerthread = threading.current_thread()
        if self._callerthreadref is not None:
            oldcallerthread = self._callerthreadref() # Create a local copy for thread-safety.
            oldcallercontext = self._callercontext
            # Do not bother checking further if the last thread that called the client has already been joined. No danger of race condition in that case
            if oldcallerthread is not None and oldcallerthread.is_alive():
                # assert oldcallerthread == callerthread, 'zmqclient used from multiple threads: previously = %s, now = %s' % (oldcallerthread, callerthread)
                if oldcallerthread.native_id != callerthread.native_id:
                    print('zmqclient used from multiple threads, this is a bug in the caller: previously = %s, now = %s, previous context = %s, new context = %s'%(repr(oldcallerthread), repr(callerthread), repr(oldcallercontext)[:100], repr(context)[:100]))

        self._callerthreadref = weakref.ref(callerthread)
        self._callercontext = context

def UseChecker(threadChecker):
    threadChecker._CheckCallerThread(threadChecker)

def UseCheckerAndSleep(threadChecker, sleepTime=1.0):
    UseChecker(threadChecker)
    print("Finished calling thread checker from thread %s!"%threading.current_thread().name)

    sleep(sleepTime)


tc = ThreadChecker()

print("Start using same ThreadChecker from multiple threads when both threads are alive")
t1 = threading.Thread(target=UseCheckerAndSleep, args=[tc, 5.0], name='T1')
t2 = threading.Thread(target=UseCheckerAndSleep, args=[tc, 1.0], name='T2')

t1.start()
sleep(1.0)
t2.start()
t1.join()
t2.join()

print('\n\n')
tc = ThreadChecker()

print("Start using same ThreadChecker from multiple threads when previous user thread is already joined")
t1 = threading.Thread(target=UseCheckerAndSleep, args=[tc, 1.0], name='T1')
t2 = threading.Thread(target=UseCheckerAndSleep, args=[tc, 1.0], name='T2')

t1.start()
t1.join() # Join t1 before starting t2
t2.start()
t2.join()

```

Output:

```
Start using same ThreadChecker from multiple threads when both threads are alive
Finished calling thread checker from thread T1!
zmqclient used from multiple threads, this is a bug in the caller: previously = <Thread(T1, started 140547465996032)>, now = <Thread(T2, started 140547457603328)>, previous context = <__main__.ThreadChecker object at 0x7fd3c1ce2910>, new context = <__main__.ThreadChecker object at 0x7fd3c1ce2910>
Finished calling thread checker from thread T2!



Start using same ThreadChecker from multiple threads when previous user thread is already joined
Finished calling thread checker from thread T1!
Finished calling thread checker from thread T2!
```

</details>

## Performance  
This is a often-called code path, so checked the effect of the change on performance with the following snippet: 

<details>
<summary>Click to expand</summary>  

```python
import threading
import weakref
import timeit

class ThreadCheckerOld():

    def __init__(self):
        self._callerthread = None
        self._callercontext = None

    def _CheckCallerThread(self, context=None):
        """Catch bad callers who use zmq client from multiple threads and cause random race conditions.
        """
        callerthread = repr(threading.current_thread())
        oldcallerthread = self._callerthread
        oldcallercontext = self._callercontext
        self._callerthread = callerthread
        self._callercontext = context
        if oldcallerthread is not None:
            # assert oldcallerthread == callerthread, 'zmqclient used from multiple threads: previously = %s, now = %s' % (oldcallerthread, callerthread)
            if oldcallerthread != callerthread:
                print('zmqclient used from multiple threads, this is a bug in the caller: previously = %s, now = %s, previous context = %s, new context = %s', oldcallerthread, callerthread, repr(oldcallercontext)[:100], repr(context)[:100])


class ThreadCheckerNew():

    def __init__(self):
        self._callerthreadref = None
        self._callercontext = None

    def _CheckCallerThread(self, context=None):
        """Catch bad callers who use zmq client from multiple threads and cause random race conditions.
        """
        callerthread = threading.current_thread()
        if self._callerthreadref is not None:
            oldcallerthread = self._callerthreadref() # Get local ref for thread-safety.
            oldcallercontext = self._callercontext
            # Do not bother checking further if the last thread that called the client has already been joined. No danger of race condition in that case
            if oldcallerthread is not None and oldcallerthread.is_alive():
                # assert oldcallerthread == callerthread, 'zmqclient used from multiple threads: previously = %s, now = %s' % (oldcallerthread, callerthread)
                if oldcallerthread.native_id != callerthread.native_id:
                    print('zmqclient used from multiple threads, this is a bug in the caller: previously = %s, now = %s, previous context = %s, new context = %s', repr(oldcallerthread), repr(callerthread), repr(oldcallercontext)[:100], repr(context)[:100])

        self._callerthreadref = weakref.ref(callerthread)
        self._callercontext = context


def ThreadCheckerClosure(threadChecker):
    def UseChecker():
        threadChecker._CheckCallerThread(threadChecker)
    return UseChecker

tcold = ThreadCheckerOld()
tcnew = ThreadCheckerNew()

iterations = 1000000
t = timeit.Timer(ThreadCheckerClosure(tcold))
print('Existing implementation took %ss for %d iterations'%(t.timeit(iterations), iterations))
t = timeit.Timer(ThreadCheckerClosure(tcnew))
print('New implementation took %ss for %d iterations'%(t.timeit(iterations), iterations))

```  
</details>  

Output:  
```
Existing implementation took 0.7496574510005303s for 1000000 iterations
New implementation took 0.5646969579975121s for 1000000 iterations
```  

The new code is slightly more performant than the existing code.