### PR TITLE
[zmqsubscriber] Fix race condition with threadInterval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.8 (2025-02-13)
+
+- Fix race condition: use threadInterval by copy as it can be modified any moment.
+
 ## 0.3.7 (2024-06-02)
 
 - Allow finishStatus/finishMessage to be specified for task StopX commands.

--- a/python/mujinzmqclient/version.py
+++ b/python/mujinzmqclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.3.7'
+__version__ = '0.3.8'
 
 # Do not forget to update CHANGELOG.md

--- a/python/mujinzmqclient/zmqsubscriber.py
+++ b/python/mujinzmqclient/zmqsubscriber.py
@@ -310,12 +310,14 @@ class ZmqThreadedSubscriber(ZmqSubscriber):
                 except Exception as e:
                     log.exception('exception caught in subscriber thread "%s": %s', self._threadName, e)
                 # rate limit the loop if desired
-                if self._threadInterval is None:
+                # Make a copy and use it because self._threadInterval is not protected by any mutex and can be modified any moment.
+                threadInterval = self._threadInterval
+                if threadInterval is None:
                     continue
                 elapsedTime = GetMonotonicTime() - starttime
-                if elapsedTime > self._threadInterval:
+                if elapsedTime > threadInterval:
                     continue
-                time.sleep(self._threadInterval - elapsedTime)
+                time.sleep(threadInterval - elapsedTime)
         except Exception as e:
             log.exception('exception caught in subscriber thread "%s": %s', self._threadName, e)
         finally:

--- a/python/mujinzmqclient/zmqsubscriber.py
+++ b/python/mujinzmqclient/zmqsubscriber.py
@@ -310,7 +310,7 @@ class ZmqThreadedSubscriber(ZmqSubscriber):
                 except Exception as e:
                     log.exception('exception caught in subscriber thread "%s": %s', self._threadName, e)
                 # rate limit the loop if desired
-                # Make a copy and use it because self._threadInterval is not protected by any mutex and can be modified any moment.
+                # Use a copy because self._threadInterval can be set to None in SetThreadInterval() at any moment.
                 threadInterval = self._threadInterval
                 if threadInterval is None:
                     continue


### PR DESCRIPTION
Need to use threadInterval by copy as it can be modified any moment.  

Without this, the following flow is possible:
1. `self._threadInterval` starts as a `float`.
2. We check it for being `None`, it passes the check
```
if self._threadInterval is None:
    continue
```
3. `self._threadInterval` is changed to be `None` by calling `SetThreadInterval()`
4. We keep using `self._threadInterval` as if it is still a `float`, while it's already `None`, getting an exception.
```
if elapsedTime > self._threadInterval:
    continue
time.sleep(self._threadInterval - elapsedTime)
```