### PR TITLE
Add py.typed marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     version=version['__version__'],
     packages=['mujinzmqclient'],
     package_dir={'mujinzmqclient': 'python/mujinzmqclient'},
+    package_data={'mujinzmqclient': ['py.typed']},
     license='Apache License, Version 2.0',
     long_description=open('README.md').read(),
     # flake8 compliance configuration


### PR DESCRIPTION
Allow typecheckers to consider this repo
```
error: Skipping analyzing "mujinzmqclient": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```