### PR TITLE
Fix the error that sensor page is stuck in the error page that shows PlotManagerError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.9 (2025-07-24)
+
+- Made the `_ReleaseSocket` function into public function `ReleaseSocket` so that user can call it.
+
 ## 0.3.8 (2025-02-13)
 
 - Fix race condition: use threadInterval by copy as it can be modified any moment.

--- a/python/mujinzmqclient/version.py
+++ b/python/mujinzmqclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.3.8'
+__version__ = '0.3.9'
 
 # Do not forget to update CHANGELOG.md

--- a/python/mujinzmqclient/zmqclient.py
+++ b/python/mujinzmqclient/zmqclient.py
@@ -315,6 +315,9 @@ class ZmqClient(object):
             self._pool.ReleaseSocket(self._socket)
             self._socket = None
     
+    def ReleaseWaitingSocket(self):
+        self._ReleaseSocket()
+    
     def SetPreemptFn(self, checkpreemptfn):
         self._checkpreemptfn = checkpreemptfn
     

--- a/python/mujinzmqclient/zmqclient.py
+++ b/python/mujinzmqclient/zmqclient.py
@@ -260,7 +260,7 @@ class ZmqClient(object):
         self.SetDestroy()
 
         if self._pool is not None:
-            self._ReleaseSocket()
+            self.ReleaseSocket()
             self._pool.Destroy()
             self._pool = None
 
@@ -307,17 +307,14 @@ class ZmqClient(object):
     
     def _AcquireSocket(self, timeout=None, checkpreempt=True):
         # If we were holding on to a socket before, release it before acquiring another one
-        self._ReleaseSocket()
+        self.ReleaseSocket()
         self._socket = self._pool.AcquireSocket(timeout=timeout, checkpreemptfn=self._checkpreemptfn if checkpreempt else None)
 
-    def _ReleaseSocket(self):
+    def ReleaseSocket(self):
         if self._socket is not None:
             self._pool.ReleaseSocket(self._socket)
             self._socket = None
-    
-    def ReleaseWaitingSocket(self):
-        self._ReleaseSocket()
-    
+
     def SetPreemptFn(self, checkpreemptfn):
         self._checkpreemptfn = checkpreemptfn
     
@@ -399,7 +396,7 @@ class ZmqClient(object):
         finally:
             # release socket
             if releasesocket:
-                self._ReleaseSocket()
+                self.ReleaseSocket()
 
         raise UserInterrupt(u'Interrupted while waiting to send, ZMQ client is stopping')
 
@@ -453,6 +450,6 @@ class ZmqClient(object):
         finally:
             if releaseSocket:
                 # Release socket
-                self._ReleaseSocket()
+                self.ReleaseSocket()
         
         raise UserInterrupt(u'Interrupted while waiting for response, ZMQ client is stopping')


### PR DESCRIPTION
# Description
There's a situation that the client sends a request and wait for the response, before it get's the response the server restarts, and then the socket client gets stuck even if the socket server restarts successfully. Since the socket server restarts, the request that the client sent to the server is lost, so the server is unable to respond to that request, and the client will keep waiting forever.<br>
To break this,  made the `_ReleaseSocket` function into public function `ReleaseSocket` in zmqclient so that sensorbridgeclient can call it to release the infinite waiting socket. Also, add a function in sensorbridgeclient for the owner of sensorbridgeclient can call to release the waiting socket.<br>
In the function that use sensorbridgeclient can then call the function added in sensorbridgeclient to release the infinite waiting socket when it the waiting SnapImages timed out.