### PR TITLE
Handle poller returning a file descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.10 (2025-12-18)
+
+- Handle poller returning a file descriptor.
+
 ## 0.3.9 (2025-07-24)
 
 - Made the `_ReleaseSocket` function into public function `ReleaseSocket` so that user can call it.

--- a/python/mujinzmqclient/__init__.py
+++ b/python/mujinzmqclient/__init__.py
@@ -41,6 +41,8 @@ except ImportError:
 
 _ = ugettext
 
+class InternalError(ClientExceptionBase):
+    pass
 
 class TimeoutError(ClientExceptionBase):
     pass

--- a/python/mujinzmqclient/version.py
+++ b/python/mujinzmqclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.3.9'
+__version__ = '0.3.10'
 
 # Do not forget to update CHANGELOG.md


### PR DESCRIPTION
According to the ZMQ documentation, poller can return a socket or a file descriptor. Currently, the code only handles receiving sockets. This PR adds handing for file descriptors.

<img width="668" height="175" alt="image" src="https://github.com/user-attachments/assets/42f1af4c-7266-42e4-b85f-b684950ac307" />

https://pyzmq.readthedocs.io/en/latest/api/zmq.html#poller