### PR TITLE
Use msgspec instead of zmq json for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.11 (2026-06-19)
+
+- Replace native json package with msgspec for decoding
+
 ## 0.3.10 (2025-12-18)
 
 - Handle poller returning a file descriptor.

--- a/python/mujinzmqclient/version.py
+++ b/python/mujinzmqclient/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.3.10'
+__version__ = "0.3.11"
 
 # Do not forget to update CHANGELOG.md

--- a/python/mujinzmqclient/zmqclient.py
+++ b/python/mujinzmqclient/zmqclient.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import ujson
 import msgspec
-import numpy
 import six
 import threading
 
@@ -272,19 +271,6 @@ class ZmqClient(object):
 
     @staticmethod
     def _JsonEncodeHook(obj: Any) -> Any:
-        # Fast path for the numpy types we encode most frequently: convert them to native python objects that msgspec then re-encodes directly.
-        # This keeps the common case off the slower generic fallback below.
-        if isinstance(
-            obj,
-            (numpy.int_, numpy.intc, numpy.intp, numpy.int8, numpy.int16, numpy.int32, numpy.int64,
-            numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64),
-        ):
-            return int(obj)
-        elif isinstance(obj, (numpy.float16, numpy.float32, numpy.float64)):
-            return float(obj)
-        if isinstance(obj, numpy.ndarray):
-            return obj.tolist()
-
         # For other types, fall back to the ujson behaviour (inferring serialization based on members).
         # Splice the encoded output via msgspec.Raw to avoid reprocessing the serialized result.
         return msgspec.Raw(ujson.dumps(obj).encode('utf-8'))

--- a/python/mujinzmqclient/zmqclient.py
+++ b/python/mujinzmqclient/zmqclient.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2012-2015 MUJIN Inc
 from typing import Any
 
+import ujson
 import msgspec
 import numpy
 import six
@@ -271,6 +272,8 @@ class ZmqClient(object):
 
     @staticmethod
     def _JsonEncodeHook(obj: Any) -> Any:
+        # Fast path for the numpy types we encode most frequently: convert them to native python objects that msgspec then re-encodes directly.
+        # This keeps the common case off the slower generic fallback below.
         if isinstance(
             obj,
             (numpy.int_, numpy.intc, numpy.intp, numpy.int8, numpy.int16, numpy.int32, numpy.int64,
@@ -281,7 +284,10 @@ class ZmqClient(object):
             return float(obj)
         if isinstance(obj, numpy.ndarray):
             return obj.tolist()
-        raise NotImplementedError(f"Cannot encode object of type {type(obj)}")
+
+        # For other types, fall back to the ujson behaviour (inferring serialization based on members).
+        # Splice the encoded output via msgspec.Raw to avoid reprocessing the serialized result.
+        return msgspec.Raw(ujson.dumps(obj).encode('utf-8'))
 
     def __del__(self):
         self.Destroy()

--- a/python/mujinzmqclient/zmqclient.py
+++ b/python/mujinzmqclient/zmqclient.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2012-2015 MUJIN Inc
+from typing import Any
 
-import threading
+import msgspec
+import numpy
 import six
+import threading
 
 from . import zmq
 from . import TimeoutError, UserInterrupt, InternalError, GetMonotonicTime
@@ -263,6 +266,22 @@ class ZmqClient(object):
         self._socket = None
         self._isok = True
         self._checkpreemptfn = checkpreemptfn
+        self._jsonEncoder = msgspec.json.Encoder(enc_hook=self._JsonEncodeHook)
+        self._jsonDecoder = msgspec.json.Decoder()
+
+    @staticmethod
+    def _JsonEncodeHook(obj: Any) -> Any:
+        if isinstance(
+            obj,
+            (numpy.int_, numpy.intc, numpy.intp, numpy.int8, numpy.int16, numpy.int32, numpy.int64,
+            numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64),
+        ):
+            return int(obj)
+        elif isinstance(obj, (numpy.float16, numpy.float32, numpy.float64)):
+            return float(obj)
+        if isinstance(obj, numpy.ndarray):
+            return obj.tolist()
+        raise NotImplementedError(f"Cannot encode object of type {type(obj)}")
 
     def __del__(self):
         self.Destroy()
@@ -300,7 +319,7 @@ class ZmqClient(object):
     @property
     def port(self):
         return self._port
-    
+
     def _CheckCallerThread(self, context=None):
         """Catch bad callers who use zmq client from multiple threads and cause random race conditions.
         """
@@ -315,7 +334,7 @@ class ZmqClient(object):
 
         self._callerthreadref = weakref.ref(callerthread)
         self._callercontext = context
-    
+
     def _AcquireSocket(self, timeout=None, checkpreempt=True):
         # If we were holding on to a socket before, release it before acquiring another one
         self.ReleaseSocket()
@@ -328,7 +347,7 @@ class ZmqClient(object):
 
     def SetPreemptFn(self, checkpreemptfn):
         self._checkpreemptfn = checkpreemptfn
-    
+
     def SendCommand(self, command, timeout=10.0, blockwait=True, fireandforget=False, sendjson=True, recvjson=True, sendmultipart=False, recvmultipart=False, checkpreempt=None):
         """Sends command via established zmq socket
 
@@ -347,7 +366,7 @@ class ZmqClient(object):
         # log.debug('Sending command via ZMQ: %s', command)
         if checkpreempt is None:
             log.warn(u'Need to specify checkpreempt to zmq client for command %r', command)
-        
+
         self._CheckCallerThread(command)
 
         if fireandforget:
@@ -382,7 +401,8 @@ class ZmqClient(object):
                     self._socket.send_multipart(command, zmq.NOBLOCK)
                 elif sendjson:
                     try:
-                        self._socket.send_json(command, zmq.NOBLOCK)
+                        commandBytes = self._jsonEncoder.encode(command)
+                        self._socket.send(commandBytes, zmq.NOBLOCK)
                     except OverflowError as e:
                         log.error('Failed sending command=%r: %s', command, e)
                         raise
@@ -424,7 +444,7 @@ class ZmqClient(object):
         :return: Returns the recv or recv_json or recv_multipart response
         """
         self._CheckCallerThread('ReceiveCommand')
-        
+
         # Should have called SendCommand with blockwait=False first
         assert (self._socket is not None)
         releaseSocket = False
@@ -445,22 +465,23 @@ class ZmqClient(object):
                         return self._socket.recv_multipart(zmq.NOBLOCK)
                     elif recvjson:
                         releaseSocket = True
-                        return self._socket.recv_json(zmq.NOBLOCK)
+                        recvMsg = self._socket.recv(zmq.NOBLOCK)
+                        return self._jsonDecoder.decode(recvMsg) if recvMsg else None
                     else:
                         releaseSocket = True
                         return self._socket.recv(zmq.NOBLOCK)
-                
+
                 # Do timeout checking at the end
                 elapsedtime = GetMonotonicTime() - starttime
                 if timeout is not None and elapsedtime > timeout:
                     raise TimeoutError(u'Timed out to get response from %s after %f seconds (timeout=%f)' % (self._url, elapsedtime, timeout))
-                
+
                 if checkpreempt and self._checkpreemptfn is not None:
                     self._checkpreemptfn()
-        
+
         finally:
             if releaseSocket:
                 # Release socket
                 self.ReleaseSocket()
-        
+
         raise UserInterrupt(u'Interrupted while waiting for response, ZMQ client is stopping')


### PR DESCRIPTION
Msgspec is faster, but needs an additional decoder hook to handle numpy / other non-standard types correctly.